### PR TITLE
🙂

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Dependencies
 
-- Node.js
+- Node.js 16
 - Angular 10
 - Three.js 0.113.0
 


### PR DESCRIPTION
Node.js over 16 doesn't seem to build on Windows 11 for me.

https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported

But 16 works. 👌